### PR TITLE
Change dependency to just GCM instead of all of the play services.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.google.android.gms:play-services:9.0.1'
+    compile 'com.google.android.gms:play-services-gcm:9.0.1'
 
     compile group: 'com.ibm.mobilefirstplatform.clientsdk.android',
             name: 'core',


### PR DESCRIPTION
Having the full Play Services SDK is a bad idea, since it is huge. This causes two issues: first, it makes compilation take much longer, and also causes dex limit issues since there are so many methods, making it pretty close to the 65,536 method count limit. This pull request simply changes the dependency from the full SDK to just the GCM SDK and its dependencies. It compiles correctly and all the tests pass, so it should be ok.

I am doing this in response to this issue: https://github.com/ibm-bluemix-mobile-services/bms-clientsdk-android-core/issues/13.
