### PR TITLE
Change the way BMSCore dependency is specified

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -77,7 +77,7 @@ def isReleaseBuild() {
 }
 
 def getVersion() {
-    return '2.0.2-SNAPSHOT'
+    return '2.0.6-SNAPSHOT'
 }
 
 uploadArchives {
@@ -134,9 +134,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.google.android.gms:play-services-gcm:9.0.1'
 
-    compile group: 'com.ibm.mobilefirstplatform.clientsdk.android',
-            name: 'core',
-            version: '2.0.1',
-            ext: 'aar',
-            transitive: true
+    compile 'com.ibm.mobilefirstplatform.clientsdk.android:core:[2.0.0,3.0.0)'
 }


### PR DESCRIPTION
We need to specify the BMSCore dependency as a JAR, not AAR, and we need to specify a version range, otherwise we will get out of sync when one SDK updates to the latest core and the rest have not, which will cause Multiple Dex linking errors for our users.
